### PR TITLE
[Countdown] Fix aware-naive comparison

### DIFF
--- a/countdown/module.py
+++ b/countdown/module.py
@@ -30,11 +30,13 @@ class Countdown(commands.Cog):
         return text
 
     def _get_remaining_time(self, countdown_item: CountdownItem) -> str:
-        if countdown_item.countdown_date < datetime.now():
+        if countdown_item.countdown_date < datetime.now().astimezone():
             return "Finished"
         else:
             return utils.time.format_seconds(
-                (countdown_item.countdown_date - datetime.now()).total_seconds()
+                (
+                    countdown_item.countdown_date - datetime.now().astimezone()
+                ).total_seconds()
             )
 
     async def _get_embed(self, ctx, countdown: CountdownItem):


### PR DESCRIPTION
Fixing error that were there for a long time (pre-strawberry times):

```
VUT FEKT: TypeError: can't compare offset-naive and offset-aware datetimes
Traceback (most recent call last):
  File "/home/discord/eliska/.venv/lib/python3.10/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/discord/eliska/modules/reminder/countdown/module.py", line 201, in countdown_delete
    embed = await self._get_embed(ctx, countdown=countdown)
  File "/home/discord/eliska/modules/reminder/countdown/module.py", line 50, in _get_embed
    name=_(ctx, "Remaining time"), value=self._get_remaining_time(countdown)
  File "/home/discord/eliska/modules/reminder/countdown/module.py", line 32, in _get_remaining_time
    if countdown_item.countdown_date < datetime.now():
TypeError: can't compare offset-naive and offset-aware datetimes
```
![image](https://github.com/strawberry-py/strawberry-reminder/assets/6602975/46935dfe-bf69-4869-824a-37063aa233c6)