### PR TITLE
[Reminder] Fix reminder list

### DIFF
--- a/reminder/module.py
+++ b/reminder/module.py
@@ -138,8 +138,10 @@ class Reminder(commands.Cog):
 
         table_pages: List[str] = utils.text.create_table(reminders[::-1], table_columns)
 
+        await itx.response.defer()
+
         for table_page in table_pages:
-            await itx.response.send_message(
+            await itx.followup.send(
                 "```" + table_page.replace("`", "'") + "```", ephemeral=True
             )
 


### PR DESCRIPTION
Fixes:
```
#bot-spam VUT FSI: CommandInvokeError: Command 'list' raised an exception: InteractionResponded: This interaction has already been responded to before
Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 858, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/reminder/reminder/module.py", line 266, in reminder_list
    await self._send_reminder_list(itx, query)
  File "/strawberry-py/modules/reminder/reminder/module.py", line 142, in _send_reminder_list
    await itx.response.send_message(
  File "/root/.local/lib/python3.12/site-packages/discord/interactions.py", line 1057, in send_message
    raise InteractionResponded(self._parent)
discord.errors.InteractionResponded: This interaction has already been responded to before
```